### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/lib/google-fix.js
+++ b/lib/google-fix.js
@@ -95,7 +95,7 @@
           // Fix for Gmail links: Check if we should open in a new tab
           const shouldOpenInNewTab = 
             anchor.target === '_blank' || 
-            window.location.hostname.includes('mail.google.com') ||
+            (window.location.hostname === 'mail.google.com' || window.location.hostname.endsWith('.mail.google.com')) ||
             anchor.getAttribute('rel')?.includes('noopener');
             
           if (shouldOpenInNewTab) {


### PR DESCRIPTION
Potential fix for [https://github.com/Linkumori/Linkumori-Extension/security/code-scanning/4](https://github.com/Linkumori/Linkumori-Extension/security/code-scanning/4)

To fix the issue, we need to replace the substring check (`includes('mail.google.com')`) with a more robust check that ensures the hostname is either `mail.google.com` or a valid subdomain of it. This can be achieved by parsing the hostname and verifying it against a whitelist of allowed domains. The `URL` API can be used to extract the hostname, and a simple comparison can ensure the hostname ends with `.mail.google.com` or matches `mail.google.com`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
