### PR TITLE
Potential fix for code scanning alert no. 1: Double escaping or unescaping

### DIFF
--- a/background.js
+++ b/background.js
@@ -755,10 +755,18 @@ function removeUrlParameters(url) {
 }
 
 function htmlcanescape(str) {
-  return String(str)
+  const decodeHtmlEntities = (s) => s
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&amp;/g, "&")
+      .replace(/&#39;/g, "'")
+      .replace(/&quot;/g, "\"");
+
+  const rawStr = decodeHtmlEntities(String(str));
+  return rawStr
+      .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
       .replace(/>/g, "&gt;")
-      .replace(/&/g, "&amp;")
       .replace(/'/g, "&#39;")
       .replace(/"/g, "&quot;");
 }

--- a/background.js
+++ b/background.js
@@ -758,9 +758,9 @@ function htmlcanescape(str) {
   const decodeHtmlEntities = (s) => s
       .replace(/&lt;/g, "<")
       .replace(/&gt;/g, ">")
-      .replace(/&amp;/g, "&")
       .replace(/&#39;/g, "'")
-      .replace(/&quot;/g, "\"");
+      .replace(/&quot;/g, "\"")
+      .replace(/&amp;/g, "&");
 
   const rawStr = decodeHtmlEntities(String(str));
   return rawStr


### PR DESCRIPTION
Potential fix for [https://github.com/Linkumori/Linkumori-Extension/security/code-scanning/1](https://github.com/Linkumori/Linkumori-Extension/security/code-scanning/1)

To fix the issue, we need to ensure that `htmlcanescape` does not double-escape already-escaped entities. This can be achieved by decoding any existing HTML entities in the input string before applying the escaping logic. A well-tested library like `he` can be used for this purpose, or we can implement a decoding step manually. The fix involves modifying the `htmlcanescape` function to first decode existing entities and then escape the string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
